### PR TITLE
Query the environment directly instead of using libc's setlocale.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Notable changes to this project will be documented in the [keep a changelog](htt
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-02-28
+
+### Fixed
+
+- Fixed a soundness issue on Linux and BSDs by querying the environment directly instead of using libc setlocale. The libc setlocale is not safe for use in a multi-threaded context.
+
+### Changed
+
+- No longer `no_std` on Linux and BSDs
+
 ## [0.1.0] - 2021-05-13
 
 Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,12 @@ license = "MIT OR Apache-2.0"
 [build-dependencies]
 cc = "1.0"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(target_os = "android")'.dependencies]
 libc = "0.2"
 
-[target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 cstr_core = "0.2"
+libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winnls"] }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 A small and lightweight Rust library to obtain the locale the active locale on the system.
 
 `sys-locale` is small library for obtaining the current locale set for the system or application with the relevant platform APIs.
-The library is also `no_std` compatible by default, only relying on `alloc`. 
+The library is also `no_std` compatible except on Linux and BSD, only relying on `alloc`.
 
 Platform support currently includes:
 - Android

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,15 @@
 //! - Linux, BSD, and other UNIX variations
 //! - WebAssembly
 //! - Windows
-#![no_std]
-
+#[cfg_attr(
+    any(
+        not(unix),
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "android"
+    ),
+    no_std
+)]
 extern crate alloc;
 use alloc::string::String;
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,56 +1,29 @@
-use alloc::string::String;
-use core::ptr::NonNull;
-use cstr_core::CStr;
+use std::env;
 
+const LC_ALL: &str = "LC_ALL";
 const LC_CTYPE: &str = "LC_CTYPE";
+const LANG: &str = "LANG";
 
 pub(crate) fn get() -> Option<String> {
-    // SAFETY: `setlocale` is being called with a known category and an empty, null-terminated string.
-    let locale = NonNull::new(unsafe { libc::setlocale(libc::LC_ALL, b"\0".as_ptr().cast()) })?;
+    let code = env::var(LC_ALL)
+        .or_else(|_| env::var(LC_CTYPE))
+        .or_else(|_| env::var(LANG))
+        .ok()?;
 
-    // SAFETY: `setlocale` returns a pointer to a NUL terminated string which
-    // is then cloned into an owned Rust string, and has otherwise been checked as non-null.
-    let code = unsafe { CStr::from_ptr(locale.as_ptr()) };
-    let code = code.to_str().ok()?;
-
-    parse_locale_code(code)
+    parse_locale_code(&code)
 }
 
 fn parse_locale_code(code: &str) -> Option<String> {
-    // Support two behaviors:
-    //
-    // - `LC_ALL` and `LANG` are set, so `setlocale` returns a single locale identifier.
-    // - `LANG` is set but `LC_ALL` is not, so `setlocale` returns a list of all identifiers.
-    //
-    // In the first case we have a clear case of which locale to use. In the second, we will fallback to using `LC_CTYPE`
-    // as its the most closely related to character localization.
-    let code = if !code.contains(LC_CTYPE) {
-        code
-    } else {
-        code.split(';')
-            .find(|c| c.starts_with(LC_CTYPE))
-            .and_then(|c| c.split('=').last())?
-    };
-
     // Some locales are returned with the char encoding too: `en_US.UTF-8`
     code.splitn(2, '.').next().map(String::from)
 }
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
-    use super::{get, parse_locale_code};
+    use super::{get, parse_locale_code, LANG, LC_ALL, LC_CTYPE};
+    use std::env;
 
-    const LC_ALL_CONTENTS: &str = "LC_CTYPE=fr_FR.UTF-8;LC_NUMERIC=en_US.UTF-8;LC_TIME=en_US.UTF-8;LC_COLLATE=fr_FR.UTF-8;LC_MONETARY=en_US.UTF-8;LC_MESSAGES=fr_FR.UTF-8;LC_PAPER=en_US.UTF-8;LC_NAME=en_US.UTF-8;LC_ADDRESS=en_US.UTF-8;LC_TELEPHONE=en_US.UTF-8;LC_MEASUREMENT=en_US.UTF-8;LC_IDENTIFICATION=en_US.UTF-8";
     const PARSE_LOCALE: &str = "fr_FR";
-
-    #[test]
-    fn parse_lc_all() {
-        assert_eq!(
-            parse_locale_code(LC_ALL_CONTENTS).as_deref(),
-            Some(PARSE_LOCALE)
-        );
-    }
 
     #[test]
     fn parse_identifier() {
@@ -67,9 +40,23 @@ mod tests {
     }
 
     #[test]
-    fn invalid_locale_doesnt_crash() {
-        std::env::set_var("LANG", "invalid");
-        std::env::set_var("LC_ALL", "invalid-again");
+    fn env_priority() {
+        env::remove_var(LANG);
+        env::remove_var(LC_ALL);
+        env::remove_var(LC_CTYPE);
         assert_eq!(get(), None);
+
+        // These locale names are technically allowed and some systems may still
+        // defined aliases such as these but the glibc sources mention that this
+        // should be considered deprecated
+
+        env::set_var(LANG, "invalid");
+        assert_eq!(get().as_deref(), Some("invalid"));
+
+        env::set_var(LC_CTYPE, "invalid-also");
+        assert_eq!(get().as_deref(), Some("invalid-also"));
+
+        env::set_var(LC_ALL, "invalid-again");
+        assert_eq!(get().as_deref(), Some("invalid-again"));
     }
 }


### PR DESCRIPTION

# Why

`setlocale` is unfortunately not safe to use in a multi-threaded application.

# How

We can avoid using it altogether by pulling the locale from the environment. Both [glibc](https://elixir.bootlin.com/glibc/glibc-2.35.9000/source/locale/findlocale.c#L118) and [FreeBSD's libc](https://github.com/freebsd/freebsd-src/blob/master/lib/libc/locale/setlocale.c#L285-L306) simply pull this out of the environment using the first set variable of:
- `LC_ALL`
- `LC_{{category}}`
- `LANG`

Since we are just using `LC_CTYPE` when libc has many different locales, we can get the same locale information by just checking three environment variables. glibc does a lot of other operations around including locale alias substitution but those don't end up affecting the name it hands back out of the `setlocale` call. 

# Drawbacks

- libc/glibc [do a little extra validation on the locale string](https://github.com/freebsd/freebsd-src/blob/master/lib/libc/locale/setlocale.c#L237-L242) and won't return a locale string if it's invalid or if matching locale data can't be loaded. With these changes, we are a slight bit less defensive for invalid locales.
- we need to remove no_std on linux/bsd to query the environment directly (instead of letting libc do it for us)