### PR TITLE
Add support for workers in WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,6 @@ libc = "0.2"
 winapi = { version = "0.3", features = ["winnls"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "0.3", features = ["Window", "Navigator"] }
+js-sys = "0.3"
+wasm-bindgen = { version = "0.2"}
+web-sys = { version = "0.3", features = ["Window", "WorkerGlobalScope", "Navigator", "WorkerNavigator"] }

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 
 A small and lightweight Rust library to obtain the locale the active locale on the system.
 
-`sys-locale` is small library for obtaining the current locale set for the system or application with the relevant platform APIs.
-The library is also `no_std` compatible except on Linux and BSD, only relying on `alloc`.
+`sys-locale` is small library for obtaining the current locale set for the system or application with the relevant platform APIs. The library is also `no_std` compatible, relying only on `alloc`, except on Linux and BSD.
 
 Platform support currently includes:
 - Android

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,5 +1,51 @@
 use alloc::string::String;
 
+use js_sys::Object;
+use wasm_bindgen::{prelude::*, JsCast, JsValue};
+
+#[derive(Clone)]
+enum GlobalType {
+    Window(web_sys::Window),
+    Worker(web_sys::WorkerGlobalScope),
+}
+
+/// Returns a handle to the global scope object.
+///
+/// Simplified version of https://github.com/rustwasm/wasm-bindgen/blob/main/crates/js-sys/src/lib.rs,
+/// which we can't use directly because it discards information about how it
+/// retrieved the global.
+fn global() -> GlobalType {
+    #[wasm_bindgen]
+    extern "C" {
+        type Global;
+
+        #[wasm_bindgen(getter, catch, static_method_of = Global, js_class = window, js_name = window)]
+        fn get_window() -> Result<Object, JsValue>;
+
+        #[wasm_bindgen(getter, catch, static_method_of = Global, js_class = self, js_name = self)]
+        fn get_self() -> Result<Object, JsValue>;
+    }
+
+    if let Ok(window) = Global::get_window() {
+        GlobalType::Window(
+            window
+                .dyn_into::<web_sys::Window>()
+                .expect("expected window to be an instance of Window"),
+        )
+    } else if let Ok(worker) = Global::get_self() {
+        GlobalType::Worker(
+            worker
+                .dyn_into::<web_sys::WorkerGlobalScope>()
+                .expect("expected self to be an instance of WorkerGlobalScope"),
+        )
+    } else {
+        panic!("Unable to find global in this environment")
+    }
+}
+
 pub(crate) fn get() -> Option<String> {
-    web_sys::window()?.navigator().language()
+    match global() {
+        GlobalType::Window(window) => window.navigator().language(),
+        GlobalType::Worker(worker) => worker.navigator().language(),
+    }
 }


### PR DESCRIPTION
## Overview

We were panicking when trying to access the locale in a worker. This is because unfortunately, `window` isn't defined, so `Navigator` has to be accessed using `self` instead. This PR implements that to make sure we can reliably use sys-locale in both normal workers as well as service workers.

## Additional thoughts

Ideally I'd like to see this sort of thing solved at a lower level, but in general the ecosystem seems to be somewhat immature in its support for anything other than page contexts. As an example - calling `web_sys::window()` (which returns an option, indicating it will gracefully handle failure) panics in a worker. This makes it hard to gracefully handle and is why my approach here was to implement some new bindings with wasm-bindgen.

I plan to see what we can do to contribute more upstream in the future but I wanted to fix this here to begin with.

## How to test

1. Clone https://github.com/oliverdunk/wasm-worker
2. Checkout the `sys-locale` branch
3. Run `make`
4. Open the server URL printed to the console

In the console, you should see the current locale printed from within a worker.