### PR TITLE
Fix implementation for Linux

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -40,7 +40,7 @@ fn parse_locale_code(code: &str) -> Option<String> {
     // TODO: Once we bump MSRV >= 1.52, remove this allow and clean up
     #[allow(clippy::manual_split_once)]
     #[allow(clippy::needless_splitn)]
-    code.splitn(2, '.').next().map(String::from)
+    code.splitn(2, '.').next().map(|s| s.replace('_', "-"))
 }
 
 #[cfg(test)]
@@ -58,7 +58,7 @@ mod tests {
         }
     }
 
-    const PARSE_LOCALE: &str = "fr_FR";
+    const PARSE_LOCALE: &str = "fr-FR";
 
     #[test]
     fn parse_identifier() {


### PR DESCRIPTION
Please refer to [issue #3] which explains the problem very well.

In Linux `sys_locale::get_locale()` returns e.g. `"de_DE"` for German as spoken in Germany, even though [BCP-47]'s systax mandates that it should be `"de-DE"`.

[issue #3]: https://github.com/1Password/sys-locale/issues/3
[BCP-47]: https://datatracker.ietf.org/doc/html/rfc5646