### PR TITLE
Port to windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,12 @@ license = "MIT OR Apache-2.0"
 [target.'cfg(target_os = "android")'.dependencies]
 libc = "0.2"
 
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winnls"] }
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.45"
+features = [
+    "Win32_Globalization",
+    "Win32_System_SystemServices"
+]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,9 +1,11 @@
 use alloc::{string::String, vec};
-use winapi::um::{winnls::GetUserDefaultLocaleName, winnt::LOCALE_NAME_MAX_LENGTH};
+use windows_sys::Win32::{
+    Globalization::GetUserDefaultLocaleName, System::SystemServices::LOCALE_NAME_MAX_LENGTH,
+};
 
 #[allow(clippy::as_conversions)]
 pub(crate) fn get() -> Option<String> {
-    let mut locale = vec![0u16; LOCALE_NAME_MAX_LENGTH];
+    let mut locale = vec![0u16; LOCALE_NAME_MAX_LENGTH as usize];
     // SAFETY: The buffer has sufficent capacity to have locales written and is valid to write to.
     let len = unsafe { GetUserDefaultLocaleName(locale.as_mut_ptr(), locale.len() as i32) };
     if len > 1 {


### PR DESCRIPTION
Most crates have ported from `winapi` (which is unmaintained) to `windows-sys`. This crate is the only crate in my dependency tree that still uses `winapi`. This PR ports this crate to use `windows-sys` instead of `winapi`.