### PR TITLE
Release 0.2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         rust:
           - stable
           # MSRV
-          - 1.46.0
+          - 1.48.0
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Notable changes to this project will be documented in the [keep a changelog](htt
 
 ## [Unreleased]
 
+# [0.2.4] - 2023-03-07
+
+### Changed
+- Removed dependency on the `winapi` crate in favor of `windows-sys`, following more of the wider ecosystem.
+
 ## [0.2.3] - 2022-11-06
 
 ### Fixed
@@ -37,9 +42,10 @@ Notable changes to this project will be documented in the [keep a changelog](htt
 
 Initial release
 
-[Unreleased]: https://github.com/1Password/sys-locale/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/1Password/sys-locale/compare/v0.2.4...HEAD
 [0.1.0]: https://github.com/1Password/sys-locale/releases/tag/v0.1.0
 [0.2.0]: https://github.com/1Password/sys-locale/releases/tag/v0.2.0
 [0.2.1]: https://github.com/1Password/sys-locale/releases/tag/v0.2.1
 [0.2.2]: https://github.com/1Password/sys-locale/releases/tag/v0.2.2
 [0.2.3]: https://github.com/1Password/sys-locale/releases/tag/v0.2.3
+[0.2.4]: https://github.com/1Password/sys-locale/releases/tag/v0.2.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sys-locale"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["1Password"]
 description = "Small and lightweight library to obtain the active system locale"
 keywords = ["locale", "i18n", "localization", "nostd"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io version](https://img.shields.io/crates/v/sys-locale.svg)](https://crates.io/crates/sys-locale)
 [![crate documentation](https://docs.rs/sys-locale/badge.svg)](https://docs.rs/sys-locale)
-![MSRV](https://img.shields.io/badge/rustc-1.46+-blue.svg)
+![MSRV](https://img.shields.io/badge/rustc-1.48+-blue.svg)
 [![crates.io downloads](https://img.shields.io/crates/d/sys-locale.svg)](https://crates.io/crates/sys-locale)
 ![CI](https://github.com/1Password/sys-locale/workflows/CI/badge.svg)
 
@@ -28,7 +28,7 @@ println!("The current locale is {}", locale);
 
 ## MSRV
 
-The Minimum Supported Rust Version is currently 1.46.0. This will be bumped to the latest stable version of Rust when needed.
+The Minimum Supported Rust Version is currently 1.48.0. This will be bumped to the latest stable version of Rust when needed.
 
 ## Credits
 

--- a/examples/get_locale.rs
+++ b/examples/get_locale.rs
@@ -1,4 +1,6 @@
 //! A small example to run on your computer to see what locale the library returns.
+#![allow(unknown_lints)]
+#![allow(clippy::uninlined_format_args)]
 
 use sys_locale::get_locale;
 


### PR DESCRIPTION
This release includes an MSRV bump to accommodate the transition to `windows-sys`. On other platforms, we still compile with older versions of `rustc` but that's not explicitly supported.