### PR TITLE
Fix support for WebAssembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Notable changes to this project will be documented in the [keep a changelog](htt
 
 ## [Unreleased]
 
+### Changed
+- The crate now only uses `wasm-bindgen` when targeting WebAssembly on the web.
+  Use the new `wasm-web` feature to target the web.
+
+### Fixed
+- The crate now compiles for unsupported platforms.
+
 # [0.2.4] - 2023-03-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Notable changes to this project will be documented in the [keep a changelog](htt
 
 ### Changed
 - The crate now only uses `wasm-bindgen` when targeting WebAssembly on the web.
-  Use the new `wasm-web` feature to target the web.
+  Use the new `js` feature to target the web.
 
 ### Fixed
 - The crate now compiles for unsupported platforms.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ features = [
     "Win32_System_SystemServices"
 ]
 
-[target.'cfg(target_family = "wasm")'.dependencies]
+[target.'cfg(all(target_family = "wasm", not(unix)))'.dependencies]
 js-sys = { version = "0.3", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 web-sys = { version = "0.3", features = ["Window", "WorkerGlobalScope", "Navigator", "WorkerNavigator"], optional = true }
 
 [features]
-wasm-web = ["js-sys", "wasm-bindgen", "web-sys"]
+js = ["js-sys", "wasm-bindgen", "web-sys"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,10 @@ features = [
     "Win32_System_SystemServices"
 ]
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3"
-wasm-bindgen = { version = "0.2"}
-web-sys = { version = "0.3", features = ["Window", "WorkerGlobalScope", "Navigator", "WorkerNavigator"] }
+[target.'cfg(target_family = "wasm")'.dependencies]
+js-sys = { version = "0.3", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
+web-sys = { version = "0.3", features = ["Window", "WorkerGlobalScope", "Navigator", "WorkerNavigator"], optional = true }
+
+[features]
+wasm-web = ["js-sys", "wasm-bindgen", "web-sys"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Platform support currently includes:
 - iOS
 - macOS
 - Linux, BSD, and other UNIX variations
-- WebAssembly
+- WebAssembly on the web
 - Windows
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Platform support currently includes:
 - iOS
 - macOS
 - Linux, BSD, and other UNIX variations
-- WebAssembly on the web
+- WebAssembly on the web (via the `js` feature)
 - Windows
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! - iOS
 //! - macOS
 //! - Linux, BSD, and other UNIX variations
-//! - WebAssembly
+//! - WebAssembly on the web
 //! - Windows
 #![cfg_attr(
     any(
@@ -40,15 +40,22 @@ mod unix;
 ))]
 use unix as provider;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_family = "wasm", feature = "wasm-web"))]
 mod wasm;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_family = "wasm", feature = "wasm-web"))]
 use wasm as provider;
 
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 mod windows;
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 use windows as provider;
+
+#[cfg(not(any(unix, all(target_family = "wasm", feature = "wasm-web"), windows)))]
+mod provider {
+    pub fn get() {
+        None
+    }
+}
 
 /// Returns the active locale for the system or application.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! - iOS
 //! - macOS
 //! - Linux, BSD, and other UNIX variations
-//! - WebAssembly on the web
+//! - WebAssembly on the web (via the `js` feature)
 //! - Windows
 #![cfg_attr(
     any(
@@ -40,9 +40,9 @@ mod unix;
 ))]
 use unix as provider;
 
-#[cfg(all(target_family = "wasm", feature = "wasm-web"))]
+#[cfg(all(target_family = "wasm", feature = "js", not(unix)))]
 mod wasm;
-#[cfg(all(target_family = "wasm", feature = "wasm-web"))]
+#[cfg(all(target_family = "wasm", feature = "js", not(unix)))]
 use wasm as provider;
 
 #[cfg(windows)]
@@ -50,9 +50,9 @@ mod windows;
 #[cfg(windows)]
 use windows as provider;
 
-#[cfg(not(any(unix, all(target_family = "wasm", feature = "wasm-web"), windows)))]
+#[cfg(not(any(unix, all(target_family = "wasm", feature = "js", not(unix)), windows)))]
 mod provider {
-    pub fn get() {
+    pub fn get() -> Option<alloc::string::String> {
         None
     }
 }


### PR DESCRIPTION
The crate previously assumed that `wasm-bindgen` can be used for every WebAssembly target. However there's essentially the following 4 targets:
 - WebAssembly on the web
 - Freestanding WebAssembly
 - WebAssembly with WASI
 - WebAssembly with Emscripten
 (And possibly more in the future)

Only `WebAssembly on the web` supports `wasm-bindgen`. Unfortunately that's not a target on its own for historical reasons, so the only way to properly support that target is through a `wasm-web` feature. All other WebAssembly targets now fall back onto a new fallback implementation that always returns `None`. The crate now also should be able to build at all on unsupported targets because of that.

This is technically a breaking change that requires a  new "major version" (0.3.0).