### PR TITLE
Add get_locales() method for preference-order list of locales

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2"
 version = "0.45"
 features = [
     "Win32_Globalization",
-    "Win32_System_SystemServices"
+    "Win32_Foundation"
 ]
 
 [target.'cfg(all(target_family = "wasm", not(unix)))'.dependencies]

--- a/src/android.rs
+++ b/src/android.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, vec, vec::Vec};
+use alloc::{string::String, vec};
 use core::convert::TryFrom;
 
 fn get_property(name: &'static [u8]) -> Option<String> {
@@ -29,10 +29,9 @@ const COUNTRY_KEY: &[u8] = b"persist.sys.country\0";
 const LOCALEVAR_KEY: &[u8] = b"persist.sys.localevar\0";
 
 // Ported from https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/jni/AndroidRuntime.cpp#431
-// Adapted to use multiple locales
-fn read_locale() -> Vec<String> {
+fn read_locale() -> Option<String> {
     if let Some(locale) = get_property(LOCALE_KEY) {
-        return vec![locale];
+        return Some(locale);
     }
 
     // Android 4.0 and below
@@ -52,11 +51,11 @@ fn read_locale() -> Vec<String> {
             }
         };
 
-        return vec![language];
+        return Some(language);
     }
 
     if let Some(locale) = get_property(PRODUCT_LOCALE_KEY) {
-        return vec![locale];
+        return Some(locale);
     }
 
     let product_language = get_property(PRODUCT_LANGUAGE_KEY);
@@ -65,12 +64,12 @@ fn read_locale() -> Vec<String> {
         (Some(mut lang), Some(region)) => {
             lang.push('-');
             lang.push_str(&region);
-            vec![lang]
+            Some(lang)
         }
-        _ => vec![],
+        _ => None,
     }
 }
 
-pub(crate) fn get() -> Vec<String> {
-    read_locale()
+pub(crate) fn get() -> impl Iterator<Item = String> {
+    read_locale().into_iter()
 }

--- a/src/android.rs
+++ b/src/android.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, vec};
+use alloc::{string::String, vec, vec::Vec};
 use core::convert::TryFrom;
 
 fn get_property(name: &'static [u8]) -> Option<String> {
@@ -29,9 +29,10 @@ const COUNTRY_KEY: &[u8] = b"persist.sys.country\0";
 const LOCALEVAR_KEY: &[u8] = b"persist.sys.localevar\0";
 
 // Ported from https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/jni/AndroidRuntime.cpp#431
-fn read_locale() -> Option<String> {
+// Adapted to use multiple locales
+fn read_locale() -> Vec<String> {
     if let Some(locale) = get_property(LOCALE_KEY) {
-        return Some(locale);
+        return vec![locale];
     }
 
     // Android 4.0 and below
@@ -51,11 +52,11 @@ fn read_locale() -> Option<String> {
             }
         };
 
-        return Some(language);
+        return vec![language];
     }
 
     if let Some(locale) = get_property(PRODUCT_LOCALE_KEY) {
-        return Some(locale);
+        return vec![locale];
     }
 
     let product_language = get_property(PRODUCT_LANGUAGE_KEY);
@@ -64,12 +65,12 @@ fn read_locale() -> Option<String> {
         (Some(mut lang), Some(region)) => {
             lang.push('-');
             lang.push_str(&region);
-            Some(lang)
+            vec![lang]
         }
-        _ => None,
+        _ => vec![],
     }
 }
 
-pub(crate) fn get() -> Option<String> {
+pub(crate) fn get() -> Vec<String> {
     read_locale()
 }

--- a/src/apple.rs
+++ b/src/apple.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, vec::Vec};
+use alloc::{string::String, vec, vec::Vec};
 use core::ffi::c_void;
 
 type CFIndex = isize;
@@ -49,7 +49,7 @@ extern "C" {
     fn CFLocaleCopyPreferredLanguages() -> CFArrayRef;
 }
 
-pub(crate) fn get() -> Option<String> {
+pub(crate) fn get() -> Vec<String> {
     let preferred_langs = unsafe {
         // SAFETY: This function is safe to call and has no invariants. Any value inside the
         // array will be owned by us.
@@ -60,10 +60,10 @@ pub(crate) fn get() -> Option<String> {
             if CFArrayGetCount(langs.0) != 0 {
                 langs
             } else {
-                return None;
+                return vec![];
             }
         } else {
-            return None;
+            return vec![];
         }
     };
 
@@ -100,7 +100,7 @@ pub(crate) fn get() -> Option<String> {
 
         // Guard against a zero-sized allocation, if that were to somehow occur.
         if capacity == 0 {
-            return None;
+            return vec![];
         }
 
         // Note: This is the number of bytes (u8) that will be written to
@@ -137,7 +137,11 @@ pub(crate) fn get() -> Option<String> {
         // This should always contain UTF-8 since we told the system to
         // write UTF-8 into the buffer, but the value is small enough that
         // using `from_utf8_unchecked` isn't worthwhile.
-        String::from_utf8(buffer).ok()
+        if let Ok(locale) = String::from_utf8(buffer) {
+            vec![locale]
+        } else {
+            vec![]
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,8 @@ mod provider {
 
 /// Returns the active locale for the system or application.
 ///
-/// This is equivalent to `get_locales().into_iter().next()` (the first entry).
+/// This may be equivalent to `get_locales().into_iter().next()` (the first entry),
+/// depending on the platform.
 ///
 /// # Returns
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@
 )]
 extern crate alloc;
 use alloc::string::String;
-use alloc::vec::Vec;
 
 #[cfg(target_os = "android")]
 mod android;
@@ -60,7 +59,7 @@ mod provider {
 
 /// Returns the active locale for the system or application.
 ///
-/// This may be equivalent to `get_locales().into_iter().next()` (the first entry),
+/// This may be equivalent to `get_locales().next()` (the first entry),
 /// depending on the platform.
 ///
 /// # Returns
@@ -78,7 +77,7 @@ mod provider {
 /// println!("The locale is {}", current_locale);
 /// ```
 pub fn get_locale() -> Option<String> {
-    get_locales().into_iter().next()
+    get_locales().next()
 }
 
 /// Returns the preferred locales for the system or application, in descending order of preference.
@@ -93,13 +92,12 @@ pub fn get_locale() -> Option<String> {
 /// ```no_run
 /// use sys_locale::get_locales;
 ///
-/// let locales = get_locales();
-/// let fallback = "en-US".to_string();
+/// let mut  locales = get_locales();
 ///
-/// println!("The most preferred locale is {}", locales.first().unwrap_or(&fallback));
-/// println!("The least preferred locale is {}", locales.last().unwrap_or(&fallback));
+/// println!("The most preferred locale is {}", locales.next().unwrap_or("en-US".to_string()));
+/// println!("The least preferred locale is {}", locales.last().unwrap_or("en-US".to_string()));
 /// ```
-pub fn get_locales() -> Vec<String> {
+pub fn get_locales() -> impl Iterator<Item = String> {
     provider::get()
 }
 
@@ -111,8 +109,7 @@ mod tests {
     #[test]
     fn can_obtain_locale() {
         let locales = get_locales();
-        assert!(!locales.is_empty(), "locales vec was empty");
-        for (i, locale) in locales.into_iter().enumerate() {
+        for (i, locale) in locales.enumerate() {
             assert!(!locale.is_empty(), "locale string {} was empty", i);
             assert!(
                 !locale.ends_with('\0'),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,11 +103,12 @@ pub fn get_locales() -> impl Iterator<Item = String> {
 
 #[cfg(test)]
 mod tests {
-    use super::get_locales;
+    use super::{get_locale, get_locales};
     extern crate std;
 
     #[test]
     fn can_obtain_locale() {
+        assert!(get_locale().is_some(), "no locales were returned");
         let locales = get_locales();
         for (i, locale) in locales.enumerate() {
             assert!(!locale.is_empty(), "locale string {} was empty", i);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ use windows as provider;
 
 #[cfg(not(any(unix, all(target_family = "wasm", feature = "js", not(unix)), windows)))]
 mod provider {
-    pub fn get() -> impl core::iter::Iterator<Item = String> {
+    pub fn get() -> impl Iterator<Item = alloc::string::String> {
         core::iter::empty()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ use windows as provider;
 
 #[cfg(not(any(unix, all(target_family = "wasm", feature = "js", not(unix)), windows)))]
 mod provider {
-    pub fn get() -> alloc::vec::Vec<alloc::string::String> {
-        alloc::vec::Vec::new()
+    pub fn get() -> impl core::iter::Iterator<Item = String> {
+        core::iter::empty()
     }
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -51,7 +51,6 @@ pub(crate) fn get() -> impl Iterator<Item = String> {
     languages
         .values()
         .into_iter()
-        .map(|v| v.dyn_into::<JsString>().ok())
-        .flatten()
+        .flat_map(|v| v.and_then(|v| v.dyn_into::<JsString>()))
         .map(String::from)
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,4 +1,5 @@
 use alloc::string::String;
+use alloc::{vec, vec::Vec};
 
 use js_sys::Object;
 use wasm_bindgen::{prelude::*, JsCast, JsValue};
@@ -43,9 +44,14 @@ fn global() -> GlobalType {
     }
 }
 
-pub(crate) fn get() -> Option<String> {
-    match global() {
+pub(crate) fn get() -> Vec<String> {
+    let locale = match global() {
         GlobalType::Window(window) => window.navigator().language(),
         GlobalType::Worker(worker) => worker.navigator().language(),
+    };
+    if let Some(locale) = locale {
+        vec![locale]
+    } else {
+        vec![]
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,7 +1,7 @@
 use alloc::string::String;
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 
-use js_sys::Object;
+use js_sys::{JsString, Object};
 use wasm_bindgen::{prelude::*, JsCast, JsValue};
 
 #[derive(Clone)]
@@ -45,13 +45,14 @@ fn global() -> GlobalType {
 }
 
 pub(crate) fn get() -> Vec<String> {
-    let locale = match global() {
-        GlobalType::Window(window) => window.navigator().language(),
-        GlobalType::Worker(worker) => worker.navigator().language(),
+    let languages = match global() {
+        GlobalType::Window(window) => window.navigator().languages(),
+        GlobalType::Worker(worker) => worker.navigator().languages(),
     };
-    if let Some(locale) = locale {
-        vec![locale]
-    } else {
-        vec![]
-    }
+    languages
+        .to_vec()
+        .into_iter()
+        .filter_map(|v| v.dyn_into::<JsString>().ok())
+        .map(String::from)
+        .collect()
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,5 +1,4 @@
 use alloc::string::String;
-use alloc::vec::Vec;
 
 use js_sys::{JsString, Object};
 use wasm_bindgen::{prelude::*, JsCast, JsValue};
@@ -44,15 +43,15 @@ fn global() -> GlobalType {
     }
 }
 
-pub(crate) fn get() -> Vec<String> {
+pub(crate) fn get() -> impl Iterator<Item = String> {
     let languages = match global() {
         GlobalType::Window(window) => window.navigator().languages(),
         GlobalType::Worker(worker) => worker.navigator().languages(),
     };
     languages
-        .to_vec()
+        .values()
         .into_iter()
-        .filter_map(|v| v.dyn_into::<JsString>().ok())
+        .map(|v| v.dyn_into::<JsString>().ok())
+        .flatten()
         .map(String::from)
-        .collect()
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,17 +1,18 @@
-use alloc::{string::String, vec};
+use alloc::{string::String, vec, vec::Vec};
 use windows_sys::Win32::{
     Globalization::GetUserDefaultLocaleName, System::SystemServices::LOCALE_NAME_MAX_LENGTH,
 };
 
 #[allow(clippy::as_conversions)]
-pub(crate) fn get() -> Option<String> {
+pub(crate) fn get() -> Vec<String> {
     let mut locale = vec![0u16; LOCALE_NAME_MAX_LENGTH as usize];
     // SAFETY: The buffer has sufficent capacity to have locales written and is valid to write to.
     let len = unsafe { GetUserDefaultLocaleName(locale.as_mut_ptr(), locale.len() as i32) };
     if len > 1 {
         let len = (len - 1) as usize;
-        String::from_utf16(&locale[..len]).ok()
-    } else {
-        None
+        if let Ok(locale) = String::from_utf16(&locale[..len]) {
+            return vec![locale];
+        }
     }
+    vec![]
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -2,7 +2,7 @@ use alloc::{string::String, vec::Vec};
 use windows_sys::Win32::Globalization::{GetUserPreferredUILanguages, MUI_LANGUAGE_NAME};
 
 #[allow(clippy::as_conversions)]
-pub(crate) fn get() -> Vec<String> {
+pub(crate) fn get() -> impl Iterator<Item = String> {
     let mut num_languages: u32 = 0;
     let mut buffer_length: u32 = 0;
 
@@ -41,5 +41,5 @@ pub(crate) fn get() -> Vec<String> {
         }
     }
 
-    result
+    result.into_iter()
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,18 +1,45 @@
-use alloc::{string::String, vec, vec::Vec};
-use windows_sys::Win32::{
-    Globalization::GetUserDefaultLocaleName, System::SystemServices::LOCALE_NAME_MAX_LENGTH,
-};
+use alloc::{string::String, vec::Vec};
+use windows_sys::Win32::Globalization::{GetUserPreferredUILanguages, MUI_LANGUAGE_NAME};
 
 #[allow(clippy::as_conversions)]
 pub(crate) fn get() -> Vec<String> {
-    let mut locale = vec![0u16; LOCALE_NAME_MAX_LENGTH as usize];
-    // SAFETY: The buffer has sufficent capacity to have locales written and is valid to write to.
-    let len = unsafe { GetUserDefaultLocaleName(locale.as_mut_ptr(), locale.len() as i32) };
-    if len > 1 {
-        let len = (len - 1) as usize;
-        if let Ok(locale) = String::from_utf16(&locale[..len]) {
-            return vec![locale];
+    let mut num_languages: u32 = 0;
+    let mut buffer_length: u32 = 0;
+
+    // Calling this with null buffer will retrieve the required buffer length
+    unsafe {
+        GetUserPreferredUILanguages(
+            MUI_LANGUAGE_NAME,
+            &mut num_languages,
+            core::ptr::null_mut(),
+            &mut buffer_length,
+        )
+    };
+
+    let mut buffer = Vec::<u16>::new();
+    buffer.resize(buffer_length as usize, 0);
+
+    // Now that we have an appropriate buffer, we can query the names
+    let mut result = Vec::with_capacity(num_languages as usize);
+    let success = unsafe {
+        GetUserPreferredUILanguages(
+            MUI_LANGUAGE_NAME,
+            &mut num_languages,
+            buffer.as_mut_ptr(),
+            &mut buffer_length,
+        )
+    } != 0;
+
+    if success {
+        // The buffer contains names split by null char (0), and ends with two null chars (00)
+        for part in buffer.split(|i| i == &0) {
+            if let Ok(locale) = String::from_utf16(part) {
+                if !locale.is_empty() {
+                    result.push(locale);
+                }
+            }
         }
     }
-    vec![]
+
+    result
 }


### PR DESCRIPTION
It's much better to get and respect a list of preferred locales, rather than a single locale or nothing. For example, someone may prefer Dutch and then French, but if your app only supports English and French, you're likely going to give them a not-preferred English despite supporting something the user actually wants.

This Implements the list behaviour on windows and wasm, but I'm not able to test the other providers atm to be able to convert those over - they'll just return either an empty vec or a vec with a single element. Apple should be easy to change for someone who can test it, but I've no idea about linux or android.

This implements #14.