### PR TITLE
Add more targets to CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
           - { os: 'ubuntu-latest', target: 'armv7-linux-androideabi', cross: true }
           - { os: 'ubuntu-latest', target: 'x86_64-linux-android', cross: true }
           - { os: 'ubuntu-latest', target: 'i686-linux-android', cross: true }
+
+          # WASM
+          - { os: 'ubuntu-latest', target: 'wasm32-unknown-unknown', cross: false, always_install_target: true }
         rust:
           - stable
           # MSRV
@@ -52,7 +55,7 @@ jobs:
           components: clippy
 
       - name: Install cross-target
-        if: matrix.triple.cross
+        if: matrix.triple.cross || matrix.triple.always_install_target
         run: rustup target add ${{ matrix.triple.target }}
 
       - uses: actions-rs/cargo@v1
@@ -62,7 +65,7 @@ jobs:
           use-cross: ${{ matrix.triple.cross }}
 
   test:
-    name: Test
+    name: Test Desktop OSes
     strategy:
       matrix:
         os:
@@ -82,6 +85,25 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+
+  test_wasm:
+    name: Test wasm32-unknown-unknown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Test wasm32
+        run: |
+          rustup target add wasm32-unknown-unknown
+          wasm-pack test --firefox --headless -- --features "js"
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,6 @@ jobs:
         with:
           command: test
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: can_obtain_locale -- --ignored
-
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,25 @@ jobs:
           rustup target add wasm32-unknown-unknown
           wasm-pack test --firefox --headless -- --features "js"
 
+  test_fallback:
+    name: Check fallback implementation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: "Clippy"
+      # Install a target that is obviously not supported and then check it to ensure
+      # the fallback target stays in sync with the other platforms.
+        run: |
+          rustup target add x86_64-unknown-none
+          cargo clippy --target x86_64-unknown-none -- -D clippy::dbg_macro -D warnings -D missing_docs -F unused_must_use
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ web-sys = { version = "0.3", features = ["Window", "WorkerGlobalScope", "Navigat
 
 [features]
 js = ["js-sys", "wasm-bindgen", "web-sys"]
+
+[target.'cfg(all(target_family = "wasm", not(unix)))'.dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,11 @@ mod tests {
     use super::{get_locale, get_locales};
     extern crate std;
 
+    #[cfg(all(target_family = "wasm", feature = "js", not(unix)))]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+    #[cfg(all(target_family = "wasm", feature = "js", not(unix)))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
     #[test]
     fn can_obtain_locale() {
         assert!(get_locale().is_some(), "no locales were returned");

--- a/tests/wasm_worker.rs
+++ b/tests/wasm_worker.rs
@@ -1,0 +1,15 @@
+#![cfg(all(target_family = "wasm", feature = "js", not(unix)))]
+
+use wasm_bindgen_test::wasm_bindgen_test as test;
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_worker);
+
+use sys_locale::{get_locale, get_locales};
+
+#[test]
+fn can_obtain_locale() {
+    assert!(get_locale().is_some(), "no locales were returned");
+    let locales = get_locales();
+    for (i, locale) in locales.enumerate() {
+        assert!(!locale.is_empty(), "locale string {} was empty", i);
+    }
+}


### PR DESCRIPTION
This PR adds testing, and checking, for the browser WASM environment. It also adds checking for the fallback target provider introduced in in #18.

Relates to #19