### PR TITLE
Updated windows-sys crate to version 0.48.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.45"
+version = "0.48"
 features = [
     "Win32_Globalization",
     "Win32_Foundation"


### PR DESCRIPTION
This PR is a small change to bump the version of the `windows-sys` dependency crate to version 0.48.