### PR TITLE
Update MSRV and fix UNIX variable skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
         triple:
           - { os: 'ubuntu-latest',  target: 'x86_64-unknown-linux-gnu', cross: false }
           - { os: 'ubuntu-latest',  target: 'i686-unknown-linux-gnu', cross: true }
-          - { os: 'macos-latest',   target: 'x86_64-apple-darwin', cross: false }
+          # `macos-latest` is now using macOS 14 and ARM64. Future runners will also
+          # be ARM64: https://github.com/actions/runner-images/issues/9741
+          - { os: 'macos-latest',   target: 'x86_64-apple-darwin', cross: false, always_install_target: true }
+          - { os: 'macos-latest',   target: 'aarch64-apple-darwin', cross: false }
           - { os: 'windows-latest', target: 'x86_64-pc-windows-msvc', cross: false }
           # iOS
           - { os: 'macos-latest', target: 'aarch64-apple-ios', cross: true }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         rust:
           - stable
           # MSRV
-          - 1.48.0
+          - 1.56.0
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["locale", "i18n", "localization", "nostd"]
 repository = "https://github.com/1Password/sys-locale"
 edition = "2018"
 license = "MIT OR Apache-2.0"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [target.'cfg(target_os = "android")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io version](https://img.shields.io/crates/v/sys-locale.svg)](https://crates.io/crates/sys-locale)
 [![crate documentation](https://docs.rs/sys-locale/badge.svg)](https://docs.rs/sys-locale)
-![MSRV](https://img.shields.io/badge/rustc-1.48+-blue.svg)
+![MSRV](https://img.shields.io/badge/rustc-1.56+-blue.svg)
 [![crates.io downloads](https://img.shields.io/crates/d/sys-locale.svg)](https://crates.io/crates/sys-locale)
 ![CI](https://github.com/1Password/sys-locale/workflows/CI/badge.svg)
 
@@ -32,7 +32,7 @@ println!("The current locale is {}", locale);
 
 ## MSRV
 
-The Minimum Supported Rust Version is currently 1.48.0. This will be bumped to the latest stable version of Rust when needed.
+The Minimum Supported Rust Version is currently 1.56.0. This will be bumped to a newer stable version of Rust when needed.
 
 ## Credits
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints)]
 use std::{env, ffi::OsStr};
 
 const LC_ALL: &str = "LC_ALL";
@@ -36,11 +35,11 @@ fn _get(env: &impl EnvAccess) -> Option<String> {
 }
 
 fn parse_locale_code(code: &str) -> Option<String> {
-    // Some locales are returned with the char encoding too: `en_US.UTF-8`
-    // TODO: Once we bump MSRV >= 1.52, remove this allow and clean up
-    #[allow(clippy::manual_split_once)]
-    #[allow(clippy::needless_splitn)]
-    code.splitn(2, '.').next().map(|s| s.replace('_', "-"))
+    // Some locales are returned with the char encoding too, such as `en_US.UTF-8`
+    code.split_once('.')
+        .map(|(s, _)| s)
+        .or(Some(code))
+        .map(|s| s.replace('_', "-"))
 }
 
 #[cfg(test)]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -22,8 +22,7 @@ pub(crate) fn get() -> impl Iterator<Item = String> {
         return Vec::new().into_iter();
     }
 
-    let mut buffer = Vec::<u16>::new();
-    buffer.resize(buffer_length as usize, 0);
+    let mut buffer = Vec::<u16>::with_capacity(buffer_length as usize);
 
     // Now that we have an appropriate buffer, we can query the names
     let mut result = Vec::with_capacity(num_languages as usize);
@@ -37,6 +36,8 @@ pub(crate) fn get() -> impl Iterator<Item = String> {
     } == TRUE;
 
     if success {
+        // SAFETY: Windows wrote the required length worth of UTF-16 into our buffer, which initialized it.
+        unsafe { buffer.set_len(buffer_length as usize) };
         // The buffer contains names split by null char (0), and ends with two null chars (00)
         for part in buffer.split(|i| *i == 0).filter(|p| !p.is_empty()) {
             if let Ok(locale) = String::from_utf16(part) {


### PR DESCRIPTION
This PR handles ~~two~~ three things:
- Updates our MSRV to 1.56, which is coming up on 3 years old as of this PR.
- Fixing CI because `macos-latest` now runs on ARM64 instead of x86.
- Applies a small fix to the environment variable reading on UNIX platforms so variables without contents are skipped and don't hinder reading from ones that may.

Closes #28 