### PR TITLE
Added Cargo crate exclude paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,12 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 rust-version = "1.56"
 
+exclude = [
+	"/.github/",
+	"/examples/",
+	"/tests/"
+]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [target.'cfg(target_os = "android")'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
1. `.github` folder is definitely unnecessary for the dependents of the library.
2. `examples` folder might be helpful for some developers, but I don't think that many people inspect the sources downloaded from crates.io and viewing this folder will always be easy on GitHub.
3. `tests` folder is probably only used in a development environment and is not that helpful for the dependents.

Excluding these folders from the Cargo crate will reduce the network and disk space consumption and lead to more concise file structure for the crate.