### PR TITLE
Improved documentation for `get_locale` and `get_locales`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,15 +57,14 @@ mod provider {
     }
 }
 
-/// Returns the active locale for the system or application.
+/// Returns the most preferred locale for the system or application.
 ///
-/// This may be equivalent to `get_locales().next()` (the first entry),
-/// depending on the platform.
+/// This is equivalent to `get_locales().next()` (the first entry).
 ///
 /// # Returns
 ///
-/// Returns `Some(String)` with a BCP-47 language tag inside. If the locale
-/// couldn't be obtained, `None` is returned instead.
+/// Returns [`Some(String)`] with a BCP 47 language tag inside.  
+/// If the locale couldn't be obtained, [`None`] is returned instead.
 ///
 /// # Example
 ///
@@ -84,8 +83,8 @@ pub fn get_locale() -> Option<String> {
 ///
 /// # Returns
 ///
-/// Returns a `Vec` with any number of BCP-47 language tags inside.
-/// If no locale preferences could be obtained, the vec will be empty.
+/// Returns an [`Iterator`] with any number of BCP 47 language tags inside.  
+/// If no locale preferences could be obtained, the iterator will be empty.
 ///
 /// # Example
 ///


### PR DESCRIPTION
Related: #22.

Documentation changes in `src/lib.rs`:

- [`get_locale`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L60-R67):
‎	1. The description of the returned locale was changed from `active` to `most preferred` to better align with the intended meaning and implementation.
	2. Rust's documentation conventions were used to highlight data types: `Some(String)` and `None`.
	3. A line break was added for improved readability.
	4. `BCP-47` was replaced with the more accurate `BCP 47`.

- [`get_locales`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L87-R87):
‎	1. The return type specified in the documentation was changed from `Vec` to `Iterator`.
	2. A line break was added for improved readability.
	3. `BCP-47` was replaced with the more accurate `BCP 47`.