### PR TITLE
Run tests on iOS using Mac Catalyst and expand Apple platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,18 @@ jobs:
         with:
           command: test
 
+  test_ios:
+    name: "Test iOS (Catalyst)"
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - name: Run iOS tests
+      run: |
+        rustup target add aarch64-apple-ios-macabi
+        cargo test --target aarch64-apple-ios-macabi
+
   test_wasm:
     name: Test wasm32-unknown-unknown
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A small and lightweight Rust library to get the current active locale on the sys
 
 Platform support currently includes:
 - Android
-- iOS
+- iOS (and derivatives such as watchOS, tvOS, and visionOS)
 - macOS
 - Linux, BSD, and other UNIX variations
 - WebAssembly, for the following platforms:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,20 +2,12 @@
 //!
 //! This library currently supports the following platforms:
 //! - Android
-//! - iOS
+//! - iOS (and derivatives such as watchOS, tvOS, and visionOS)
 //! - macOS
 //! - Linux, BSD, and other UNIX variations
 //! - WebAssembly on the web (via the `js` feature)
 //! - Windows
-#![cfg_attr(
-    any(
-        not(unix),
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "android"
-    ),
-    no_std
-)]
+#![cfg_attr(any(not(unix), target_vendor = "apple", target_os = "android"), no_std)]
 extern crate alloc;
 use alloc::string::String;
 
@@ -24,20 +16,14 @@ mod android;
 #[cfg(target_os = "android")]
 use android as provider;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_vendor = "apple")]
 mod apple;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_vendor = "apple")]
 use apple as provider;
 
-#[cfg(all(
-    unix,
-    not(any(target_os = "macos", target_os = "ios", target_os = "android"))
-))]
+#[cfg(all(unix, not(any(target_vendor = "apple", target_os = "android"))))]
 mod unix;
-#[cfg(all(
-    unix,
-    not(any(target_os = "macos", target_os = "ios", target_os = "android"))
-))]
+#[cfg(all(unix, not(any(target_vendor = "apple", target_os = "android"))))]
 use unix as provider;
 
 #[cfg(all(target_family = "wasm", feature = "js", not(unix)))]


### PR DESCRIPTION
This mirrors some work I did on `rustls-platform-verifier` to expand the usable Apple OSes this crate compiles for and to improve CI testing for some of them.

Relates to #23 