### PR TITLE
Add cargo-semver-checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,3 +155,12 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2


### PR DESCRIPTION
This helps reduce the manual burden and stress when creating releases, as any uncaught breaking changes will now (for the most part) be flagged during the release preparation PR CI instead.